### PR TITLE
fix time_stub calling convention

### DIFF
--- a/openinputlagpatch/dllmain.cpp
+++ b/openinputlagpatch/dllmain.cpp
@@ -100,7 +100,7 @@ void check_vpatch() {
 // The game calls these functions a bunch of times to set the system timer to 1ms
 // It's not very effective because it only sets the timer for incredibly small periods of time
 // This ensures that the system timer is set to 1ms for the entirety of the process' lifetime
-MMRESULT WINAPI time_stub() {
+MMRESULT WINAPI time_stub(UINT uPeriod) {
     return MMSYSERR_NOERROR;
 }
 


### PR DESCRIPTION
time_stub does not have the same calling convention as timeBeginPeriod and timeEndPeriod. The Windows functions take a parameter and stack cleanup is done by the callee. time_stub does not perfom any stack cleanup resulting in a stack misalignment